### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/tmechworks/lang/en_US.lang
+++ b/src/main/resources/assets/tmechworks/lang/en_US.lang
@@ -1,8 +1,11 @@
 itemGroup.TMechworks=TMechworks
 
+tile.tmechworks.signalbus.name=Signal Bus
 tile.signalbus.name=Signal Bus
+tile.tmechworks.signalterminal.name=Signal Terminal
 tile.signalterminal.name=Signal Terminal
 tile.tmechworks.dynamo.name=Dynamo
+tile.tmechworks.meshFilter.name=Mesh Filter
 tile.tmechworks.meshFilter.empty.name=Empty Mesh Filter
 tile.tmechworks.meshFilter.wide.name=Wide Mesh Filter
 tile.tmechworks.meshFilter.slat.name=Slat Mesh Filter
@@ -12,6 +15,7 @@ tile.tmechworks.meshFilter.fine.name=Fine Mesh Filter
 item.spoolwire.name=Spool of Wire
 item.lengthwire.name=Length of Wire
 
+tile.tmechworks.redstoneMachine.name=Machine
 block.drawbridge.name=Drawbridge
 block.firestarter.name=Igniter
 block.advdrawbridge.name=Advanced Drawbridge


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.